### PR TITLE
feat: add support for 0-9 key input

### DIFF
--- a/.homeycompose/capabilities/key_digit_0.json
+++ b/.homeycompose/capabilities/key_digit_0.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "0",
+    "nl": "0",
+    "de": "0",
+    "fr": "0",
+    "it": "0",
+    "sv": "0",
+    "no": "0",
+    "es": "0",
+    "da": "0",
+    "pl": "0"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_0.svg"
+}

--- a/.homeycompose/capabilities/key_digit_1.json
+++ b/.homeycompose/capabilities/key_digit_1.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "1",
+    "nl": "1",
+    "de": "1",
+    "fr": "1",
+    "it": "1",
+    "sv": "1",
+    "no": "1",
+    "es": "1",
+    "da": "1",
+    "pl": "1"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_1.svg"
+}

--- a/.homeycompose/capabilities/key_digit_2.json
+++ b/.homeycompose/capabilities/key_digit_2.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "2",
+    "nl": "2",
+    "de": "2",
+    "fr": "2",
+    "it": "2",
+    "sv": "2",
+    "no": "2",
+    "es": "2",
+    "da": "2",
+    "pl": "2"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_2.svg"
+}

--- a/.homeycompose/capabilities/key_digit_3.json
+++ b/.homeycompose/capabilities/key_digit_3.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "3",
+    "nl": "3",
+    "de": "3",
+    "fr": "3",
+    "it": "3",
+    "sv": "3",
+    "no": "3",
+    "es": "3",
+    "da": "3",
+    "pl": "3"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_3.svg"
+}

--- a/.homeycompose/capabilities/key_digit_4.json
+++ b/.homeycompose/capabilities/key_digit_4.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "4",
+    "nl": "4",
+    "de": "4",
+    "fr": "4",
+    "it": "4",
+    "sv": "4",
+    "no": "4",
+    "es": "4",
+    "da": "4",
+    "pl": "4"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_4.svg"
+}

--- a/.homeycompose/capabilities/key_digit_5.json
+++ b/.homeycompose/capabilities/key_digit_5.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "5",
+    "nl": "5",
+    "de": "5",
+    "fr": "5",
+    "it": "5",
+    "sv": "5",
+    "no": "5",
+    "es": "5",
+    "da": "5",
+    "pl": "5"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_5.svg"
+}

--- a/.homeycompose/capabilities/key_digit_6.json
+++ b/.homeycompose/capabilities/key_digit_6.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "6",
+    "nl": "6",
+    "de": "6",
+    "fr": "6",
+    "it": "6",
+    "sv": "6",
+    "no": "6",
+    "es": "6",
+    "da": "6",
+    "pl": "6"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_6.svg"
+}

--- a/.homeycompose/capabilities/key_digit_7.json
+++ b/.homeycompose/capabilities/key_digit_7.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "7",
+    "nl": "7",
+    "de": "7",
+    "fr": "7",
+    "it": "7",
+    "sv": "7",
+    "no": "7",
+    "es": "7",
+    "da": "7",
+    "pl": "7"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_7.svg"
+}

--- a/.homeycompose/capabilities/key_digit_8.json
+++ b/.homeycompose/capabilities/key_digit_8.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "8",
+    "nl": "8",
+    "de": "8",
+    "fr": "8",
+    "it": "8",
+    "sv": "8",
+    "no": "8",
+    "es": "8",
+    "da": "8",
+    "pl": "8"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_8.svg"
+}

--- a/.homeycompose/capabilities/key_digit_9.json
+++ b/.homeycompose/capabilities/key_digit_9.json
@@ -1,0 +1,20 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "9",
+    "nl": "9",
+    "de": "9",
+    "fr": "9",
+    "it": "9",
+    "sv": "9",
+    "no": "9",
+    "es": "9",
+    "da": "9",
+    "pl": "9"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "uiQuickAction": true,
+  "icon": "assets/capabilities/digit_9.svg"
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The app provides various commands to your TV, such as:
 - Confirm
 - Home
 - Set input to HDMI 1
+- 0-9 key
 
 ## Requirements
 To use this app, you need to connect your Android device to your Homey. Please note that because this requires a local connection to your TV, it needs a Homey Pro to function properly.

--- a/app.json
+++ b/app.json
@@ -577,7 +577,17 @@
         "key_watch_tv",
         "key_channel_up",
         "key_channel_down",
-        "key_source"
+        "key_source",
+        "key_digit_0",
+        "key_digit_1",
+        "key_digit_2",
+        "key_digit_3",
+        "key_digit_4",
+        "key_digit_5",
+        "key_digit_6",
+        "key_digit_7",
+        "key_digit_8",
+        "key_digit_9"
       ],
       "id": "remote",
       "settings": [
@@ -771,6 +781,206 @@
       "uiComponent": "button",
       "uiQuickAction": true,
       "icon": "assets/capabilities/cursor_up.svg"
+    },
+    "key_digit_0": {
+      "type": "boolean",
+      "title": {
+        "en": "0",
+        "nl": "0",
+        "de": "0",
+        "fr": "0",
+        "it": "0",
+        "sv": "0",
+        "no": "0",
+        "es": "0",
+        "da": "0",
+        "pl": "0"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_0.svg"
+    },
+    "key_digit_1": {
+      "type": "boolean",
+      "title": {
+        "en": "1",
+        "nl": "1",
+        "de": "1",
+        "fr": "1",
+        "it": "1",
+        "sv": "1",
+        "no": "1",
+        "es": "1",
+        "da": "1",
+        "pl": "1"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_1.svg"
+    },
+    "key_digit_2": {
+      "type": "boolean",
+      "title": {
+        "en": "2",
+        "nl": "2",
+        "de": "2",
+        "fr": "2",
+        "it": "2",
+        "sv": "2",
+        "no": "2",
+        "es": "2",
+        "da": "2",
+        "pl": "2"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_2.svg"
+    },
+    "key_digit_3": {
+      "type": "boolean",
+      "title": {
+        "en": "3",
+        "nl": "3",
+        "de": "3",
+        "fr": "3",
+        "it": "3",
+        "sv": "3",
+        "no": "3",
+        "es": "3",
+        "da": "3",
+        "pl": "3"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_3.svg"
+    },
+    "key_digit_4": {
+      "type": "boolean",
+      "title": {
+        "en": "4",
+        "nl": "4",
+        "de": "4",
+        "fr": "4",
+        "it": "4",
+        "sv": "4",
+        "no": "4",
+        "es": "4",
+        "da": "4",
+        "pl": "4"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_4.svg"
+    },
+    "key_digit_5": {
+      "type": "boolean",
+      "title": {
+        "en": "5",
+        "nl": "5",
+        "de": "5",
+        "fr": "5",
+        "it": "5",
+        "sv": "5",
+        "no": "5",
+        "es": "5",
+        "da": "5",
+        "pl": "5"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_5.svg"
+    },
+    "key_digit_6": {
+      "type": "boolean",
+      "title": {
+        "en": "6",
+        "nl": "6",
+        "de": "6",
+        "fr": "6",
+        "it": "6",
+        "sv": "6",
+        "no": "6",
+        "es": "6",
+        "da": "6",
+        "pl": "6"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_6.svg"
+    },
+    "key_digit_7": {
+      "type": "boolean",
+      "title": {
+        "en": "7",
+        "nl": "7",
+        "de": "7",
+        "fr": "7",
+        "it": "7",
+        "sv": "7",
+        "no": "7",
+        "es": "7",
+        "da": "7",
+        "pl": "7"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_7.svg"
+    },
+    "key_digit_8": {
+      "type": "boolean",
+      "title": {
+        "en": "8",
+        "nl": "8",
+        "de": "8",
+        "fr": "8",
+        "it": "8",
+        "sv": "8",
+        "no": "8",
+        "es": "8",
+        "da": "8",
+        "pl": "8"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_8.svg"
+    },
+    "key_digit_9": {
+      "type": "boolean",
+      "title": {
+        "en": "9",
+        "nl": "9",
+        "de": "9",
+        "fr": "9",
+        "it": "9",
+        "sv": "9",
+        "no": "9",
+        "es": "9",
+        "da": "9",
+        "pl": "9"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "uiQuickAction": true,
+      "icon": "assets/capabilities/digit_9.svg"
     },
     "key_fast_forward": {
       "type": "boolean",

--- a/drivers/remote/client.ts
+++ b/drivers/remote/client.ts
@@ -20,6 +20,32 @@ export interface Volume {
   muted: boolean;
 }
 
+export enum Digit {
+  Digit0,
+  Digit1,
+  Digit2,
+  Digit3,
+  Digit4,
+  Digit5,
+  Digit6,
+  Digit7,
+  Digit8,
+  Digit9,
+}
+
+const digitRemoteKeyCodeMap: { [Key in Digit]: number} = {
+  [Digit.Digit0]: RemoteKeyCode.KEYCODE_0,
+  [Digit.Digit1]: RemoteKeyCode.KEYCODE_1,
+  [Digit.Digit2]: RemoteKeyCode.KEYCODE_2,
+  [Digit.Digit3]: RemoteKeyCode.KEYCODE_3,
+  [Digit.Digit4]: RemoteKeyCode.KEYCODE_4,
+  [Digit.Digit5]: RemoteKeyCode.KEYCODE_5,
+  [Digit.Digit6]: RemoteKeyCode.KEYCODE_6,
+  [Digit.Digit7]: RemoteKeyCode.KEYCODE_7,
+  [Digit.Digit8]: RemoteKeyCode.KEYCODE_8,
+  [Digit.Digit9]: RemoteKeyCode.KEYCODE_9,
+}
+
 export default class AndroidTVRemoteClient {
   private client: AndroidRemote;
 
@@ -196,6 +222,14 @@ export default class AndroidTVRemoteClient {
 
   public sendKeyMenu(direction: number | null = null): void {
     this.client.sendKey(RemoteKeyCode.KEYCODE_MENU, direction || RemoteDirection.SHORT)
+  }
+
+  public sendKeyDigit(digit: Digit, direction: number | null = null): void {
+    if(digit in digitRemoteKeyCodeMap) {
+      this.client.sendKey(digitRemoteKeyCodeMap[digit], direction || RemoteDirection.SHORT)
+    } else {
+      throw new Error('Invalid digit');
+    }
   }
 
   public openApplication(application: string): void {

--- a/drivers/remote/device.ts
+++ b/drivers/remote/device.ts
@@ -1,6 +1,6 @@
 import {Remote} from "../../remote";
 import {DeviceSettings, DeviceStore, SettingsInput} from "./types";
-import AndroidTVRemoteClient, {Input, Volume} from "./client";
+import AndroidTVRemoteClient, {Digit, Input, Volume} from "./client";
 import RemoteMessage from "../../androidtv-remote/remote/RemoteMessage";
 
 /**
@@ -34,16 +34,16 @@ class RemoteDevice extends Remote {
     'key_channel_up',
     'key_channel_down',
     // 'key_info',
-    // 'key_digit_1',
-    // 'key_digit_2',
-    // 'key_digit_3',
-    // 'key_digit_4',
-    // 'key_digit_5',
-    // 'key_digit_6',
-    // 'key_digit_7',
-    // 'key_digit_8',
-    // 'key_digit_9',
-    // 'key_digit_0',
+    'key_digit_1',
+    'key_digit_2',
+    'key_digit_3',
+    'key_digit_4',
+    'key_digit_5',
+    'key_digit_6',
+    'key_digit_7',
+    'key_digit_8',
+    'key_digit_9',
+    'key_digit_0',
     // 'key_dot',
     'key_options',
     'key_back',
@@ -223,32 +223,31 @@ class RemoteDevice extends Remote {
       return this.client?.sendKeyDpadRight();
     } else if (typeof capability.key_cursor_down !== 'undefined') {
       return this.client?.sendKeyDpadDown();
+    } else if (typeof capability.key_digit_0 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit0)
+    } else if (typeof capability.key_digit_1 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit1)
+    } else if (typeof capability.key_digit_2 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit2)
+    } else if (typeof capability.key_digit_3 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit3)
+    } else if (typeof capability.key_digit_4 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit4)
+    } else if (typeof capability.key_digit_5 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit5)
+    } else if (typeof capability.key_digit_6 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit6)
+    } else if (typeof capability.key_digit_7 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit7)
+    } else if (typeof capability.key_digit_8 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit8)
+    } else if (typeof capability.key_digit_9 !== 'undefined') {
+        return this.client?.sendKeyDigit(Digit.Digit9)
     }
         // else if (typeof capability.key_info !== 'undefined') {
         //     return this.sendKey('Info')
-        // } else if (typeof capability.key_digit_0 !== 'undefined') {
-        //     return this.sendKey('Digit0')
-        // } else if (typeof capability.key_digit_1 !== 'undefined') {
-        //     return this.sendKey('Digit1')
-        // } else if (typeof capability.key_digit_2 !== 'undefined') {
-        //     return this.sendKey('Digit2')
-        // } else if (typeof capability.key_digit_3 !== 'undefined') {
-        //     return this.sendKey('Digit3')
-        // } else if (typeof capability.key_digit_4 !== 'undefined') {
-        //     return this.sendKey('Digit4')
-        // } else if (typeof capability.key_digit_5 !== 'undefined') {
-        //     return this.sendKey('Digit5')
-        // } else if (typeof capability.key_digit_6 !== 'undefined') {
-        //     return this.sendKey('Digit6')
-        // } else if (typeof capability.key_digit_7 !== 'undefined') {
-        //     return this.sendKey('Digit7')
-        // } else if (typeof capability.key_digit_8 !== 'undefined') {
-        //     return this.sendKey('Digit8')
-        // } else if (typeof capability.key_digit_9 !== 'undefined') {
-        //     return this.sendKey('Digit9')
         // } else if (typeof capability.key_dot !== 'undefined') {
         //     return this.sendKey('Dot')
-    // }
     else if (typeof capability.key_options !== 'undefined') {
       return this.client?.sendKeyMenu();
     } else if (typeof capability.key_back !== 'undefined') {
@@ -387,6 +386,26 @@ class RemoteDevice extends Remote {
       this.client?.sendKeyBack(direction);
     } else if (key === 'key_home') {
       this.client?.sendKeyHome(direction);
+    } else if(key === 'key_digit_0') {
+      this.client?.sendKeyDigit(Digit.Digit0, direction);
+    } else if(key === 'key_digit_1') {
+      this.client?.sendKeyDigit(Digit.Digit1, direction);
+    } else if(key === 'key_digit_2') {
+      this.client?.sendKeyDigit(Digit.Digit2, direction);
+    } else if(key === 'key_digit_3') {
+      this.client?.sendKeyDigit(Digit.Digit3, direction);
+    } else if(key === 'key_digit_4') {
+      this.client?.sendKeyDigit(Digit.Digit4, direction);
+    } else if(key === 'key_digit_5') {
+      this.client?.sendKeyDigit(Digit.Digit5, direction);
+    } else if(key === 'key_digit_6') {
+      this.client?.sendKeyDigit(Digit.Digit6, direction);
+    } else if(key === 'key_digit_7') {
+      this.client?.sendKeyDigit(Digit.Digit7, direction);
+    } else if(key === 'key_digit_8') {
+      this.client?.sendKeyDigit(Digit.Digit8, direction);
+    } else if(key === 'key_digit_9') {
+      this.client?.sendKeyDigit(Digit.Digit9, direction);
     }
   }
 
@@ -496,6 +515,46 @@ class RemoteDevice extends Remote {
         key: 'key_home',
         name: this.homey.__(`key.home`)
       },
+      {
+        key: 'key_digit_0',
+        name: this.homey.__(`key.digit_0`)
+      },
+      {
+        key: 'key_digit_1',
+        name: this.homey.__(`key.digit_1`)
+      },
+      {
+        key: 'key_digit_2',
+        name: this.homey.__(`key.digit_2`)
+      },
+      {
+        key: 'key_digit_3',
+        name: this.homey.__(`key.digit_3`)
+      },
+      {
+        key: 'key_digit_4',
+        name: this.homey.__(`key.digit_4`)
+      },
+      {
+        key: 'key_digit_5',
+        name: this.homey.__(`key.digit_5`)
+      },
+      {
+        key: 'key_digit_6',
+        name: this.homey.__(`key.digit_6`)
+      },
+      {
+        key: 'key_digit_7',
+        name: this.homey.__(`key.digit_7`)
+      },
+      {
+        key: 'key_digit_8',
+        name: this.homey.__(`key.digit_8`)
+      },
+      {
+        key: 'key_digit_9',
+        name: this.homey.__(`key.digit_9`)
+      }
     ];
   }
 }

--- a/drivers/remote/driver.compose.json
+++ b/drivers/remote/driver.compose.json
@@ -159,6 +159,16 @@
     "key_watch_tv",
     "key_channel_up",
     "key_channel_down",
-    "key_source"
+    "key_source",
+    "key_digit_0",
+    "key_digit_1",
+    "key_digit_2",
+    "key_digit_3",
+    "key_digit_4",
+    "key_digit_5",
+    "key_digit_6",
+    "key_digit_7",
+    "key_digit_8",
+    "key_digit_9"
   ]
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -36,6 +36,16 @@
     "channel_down": "Kanal ned",
     "options": "Indstillinger",
     "back": "Tilbage",
-    "home": "Hjem"
+    "home": "Hjem",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -36,6 +36,16 @@
     "channel_down": "Sender runter",
     "options": "Optionen",
     "back": "Zurück",
-    "home": "Home"
+    "home": "Home",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,6 +36,16 @@
     "channel_down": "Channel down",
     "options": "Options",
     "back": "Back",
-    "home": "Home"
+    "home": "Home",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -36,6 +36,16 @@
     "channel_down": "Bajar canal",
     "options": "Opciones",
     "back": "Atrás",
-    "home": "Inicio"
+    "home": "Inicio",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -36,6 +36,16 @@
     "channel_down": "Descendre la chaîne",
     "options": "Options",
     "back": "Retour",
-    "home": "Accueil"
+    "home": "Accueil",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -36,6 +36,16 @@
     "channel_down": "Canale giù",
     "options": "Opzioni",
     "back": "Indietro",
-    "home": "Home"
+    "home": "Home",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -36,6 +36,16 @@
     "channel_down": "Kanaal omlaag",
     "options": "Opties",
     "back": "Terug",
-    "home": "Start"
+    "home": "Start",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/no.json
+++ b/locales/no.json
@@ -36,6 +36,16 @@
     "channel_down": "Kanal ned",
     "options": "Alternativer",
     "back": "Tilbake",
-    "home": "Hjem"
+    "home": "Hjem",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -36,6 +36,16 @@
     "channel_down": "Zmniejsz kanał",
     "options": "Opcje",
     "back": "Powrót",
-    "home": "Strona główna"
+    "home": "Strona główna",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -36,6 +36,16 @@
     "channel_down": "Byt ner kanal",
     "options": "Alternativ",
     "back": "Tillbaka",
-    "home": "Hem"
+    "home": "Hem",
+    "digit_0": "0",
+    "digit_1": "1",
+    "digit_2": "2",
+    "digit_3": "3",
+    "digit_4": "4",
+    "digit_5": "5",
+    "digit_6": "6",
+    "digit_7": "7",
+    "digit_8": "8",
+    "digit_9": "9"
   }
 }


### PR DESCRIPTION
This PR adds (/brings back?) support for 0-9 key input. It maps `key_digit_*` to the respective `RemoteKeyCode.KEYCODE_*` from the Android TV remote.

Confirmed working on a KPN TV Box (Sagemcom DIW7022). I have not tested it on other Android TV devices.

Please review and do not hesitate to provide feedback, even the smallest suggestions are much appreciated! 

Potentially addresses https://github.com/lucasvdh/codes.lucasvdh.android-tv/issues/6